### PR TITLE
Use bake_cookie() in finalize_plack_response()

### DIFF
--- a/lib/HTTP/Session2/Base.pm
+++ b/lib/HTTP/Session2/Base.pm
@@ -133,7 +133,8 @@ sub finalize_plack_response {
 
     my @cookies = $self->finalize();
     while (my ($name, $cookie) = splice @cookies, 0, 2) {
-        $res->cookies->{$name} = $cookie;
+        my $baked = Cookie::Baker::bake_cookie( $name, $cookie );
+        $res->headers->push_header('Set-Cookie' => $baked);
     }
 }
 

--- a/t/04_plack_response.t
+++ b/t/04_plack_response.t
@@ -7,21 +7,41 @@ use Plack::Response;
 use HTTP::Session2::ClientStore;
 use Test::WWW::Mechanize::PSGI;
 
-my $app = sub {
-    my $env = shift;
+{
+    my $app = sub {
+        my $env = shift;
 
-    my $session = HTTP::Session2::ClientStore->new(env => $env, secret => 'yes. i am secret man.');
-    $session->set(foo => 'bar');
+        my $session = HTTP::Session2::ClientStore->new(env => $env, secret => 'yes. i am secret man.');
+        $session->set(foo => 'bar');
 
-    my $res = Plack::Response->new(200);
-    $session->finalize_plack_response($res);
-    return $res->finalize;
-};
+        my $res = Plack::Response->new(200);
+        $session->finalize_plack_response($res);
+        return $res->finalize;
+    };
 
-my $mech = Test::WWW::Mechanize::PSGI->new(app => $app, max_redirect => 0);
-$mech->get('/');
-note $mech->response->headers->as_string;
-is cookie_count($mech), 2;
+    my $mech = Test::WWW::Mechanize::PSGI->new(app => $app, max_redirect => 0);
+    $mech->get('/');
+    note $mech->response->headers->as_string;
+    is cookie_count($mech), 2;
+}
+
+{
+    my $app = sub {
+        my $env = shift;
+
+        my $session = HTTP::Session2::ClientStore->new(env => $env, secret => 'yes. i am secret man.');
+        $session->expire;
+
+        my $res = Plack::Response->new(200);
+        $session->finalize_plack_response($res);
+        return $res->finalize;
+    };
+
+    my $mech = Test::WWW::Mechanize::PSGI->new(app => $app, max_redirect => 0);
+    $mech->get('/');
+    note $mech->response->headers->as_string;
+    is cookie_count($mech), 0;
+}
 
 done_testing;
 


### PR DESCRIPTION
finalize_plack_response()でfinalizeした場合に、finalize_psgi_response()では有効なexpires => '-1d'のような表記が無効になる問題のfixです。

ヘッダに直接設定してしまうのは微妙な感じなのですが、ほかにいい手が思い付きませんでした。
