### PR TITLE
Mark HTTP::Session2 as deprecated

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,13 +4,13 @@
       "tokuhirom <tokuhirom@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.9, CPAN::Meta::Converter version 2.150010",
+   "generated_by" : "Minilla/v3.1.29, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2
    },
    "name" : "HTTP-Session2",
    "no_index" : {
@@ -35,7 +35,7 @@
          "requires" : {
             "Test::CPAN::Meta" : "0",
             "Test::MinimumVersion::Fast" : "0.04",
-            "Test::PAUSE::Permissions" : "0.04",
+            "Test::PAUSE::Permissions" : "0.07",
             "Test::Pod" : "1.41",
             "Test::Spellunker" : "v0.2.7"
          }
@@ -73,14 +73,16 @@
       "homepage" : "https://github.com/tokuhirom/HTTP-Session2",
       "repository" : {
          "type" : "git",
-         "url" : "git://github.com/tokuhirom/HTTP-Session2.git",
+         "url" : "https://github.com/tokuhirom/HTTP-Session2.git",
          "web" : "https://github.com/tokuhirom/HTTP-Session2"
       }
    },
    "version" : "1.10",
    "x_contributors" : [
-      "magai <xxmagai@gmail.com>",
-      "Songmu <y.songmu@gmail.com>"
+      "Songmu <y.songmu@gmail.com>",
+      "magai <xxmagai@gmail.com>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27400"
+   "x_deprecated" : 1,
+   "x_serialization_backend" : "JSON::PP version 4.16",
+   "x_static_install" : 1
 }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 HTTP::Session2 - HTTP session management
 
+# DEPRECATION NOTICE
+
+This module is **DEPRECATED** and no longer maintained.
+Please do not use this module for new projects.
+
 # SYNOPSIS
 
     package MyApp;

--- a/lib/HTTP/Session2.pm
+++ b/lib/HTTP/Session2.pm
@@ -16,6 +16,11 @@ __END__
 
 HTTP::Session2 - HTTP session management
 
+=head1 DEPRECATION NOTICE
+
+This module is B<DEPRECATED> and no longer maintained.
+Please do not use this module for new projects.
+
 =head1 SYNOPSIS
 
     package MyApp;

--- a/lib/HTTP/Session2/Base.pm
+++ b/lib/HTTP/Session2/Base.pm
@@ -163,7 +163,13 @@ __END__
 
 =head1 NAME
 
-HTTP::Session2 - Abstract base class for HTTP::Session2
+HTTP::Session2::Base - Abstract base class for HTTP::Session2
+
+=head1 DEPRECATION NOTICE
+
+This module is B<DEPRECATED> and no longer maintained.
+Please do not use this module for new projects.
+See L<HTTP::Session2> for details.
 
 =head1 DESCRIPTION
 

--- a/lib/HTTP/Session2/ClientStore.pm
+++ b/lib/HTTP/Session2/ClientStore.pm
@@ -168,7 +168,13 @@ __END__
 
 =head1 NAME
 
-HTTP::Session2::ClientStore - (Deprecated)Client store
+HTTP::Session2::ClientStore - (Deprecated) Client store
+
+=head1 DEPRECATION NOTICE
+
+This module is B<DEPRECATED> and no longer maintained.
+Please do not use this module for new projects.
+See L<HTTP::Session2> for details.
 
 =head1 DESCRIPTION
 

--- a/lib/HTTP/Session2/ClientStore2.pm
+++ b/lib/HTTP/Session2/ClientStore2.pm
@@ -200,6 +200,12 @@ __END__
 
 HTTP::Session2::ClientStore2 - Client store
 
+=head1 DEPRECATION NOTICE
+
+This module is B<DEPRECATED> and no longer maintained.
+Please do not use this module for new projects.
+See L<HTTP::Session2> for details.
+
 =head1 DESCRIPTION
 
 This is a part of L<HTTP::Session2> library.

--- a/lib/HTTP/Session2/ServerStore.pm
+++ b/lib/HTTP/Session2/ServerStore.pm
@@ -173,6 +173,12 @@ __END__
 
 HTTP::Session2::ServerStore - Session store
 
+=head1 DEPRECATION NOTICE
+
+This module is B<DEPRECATED> and no longer maintained.
+Please do not use this module for new projects.
+See L<HTTP::Session2> for details.
+
 =head1 DESCRIPTION
 
 This module is a part of HTTP::Session2 library.

--- a/minil.toml
+++ b/minil.toml
@@ -1,2 +1,5 @@
 name = "HTTP-Session2"
 badges = ["travis", "coveralls"]
+
+[Metadata]
+x_deprecated = 1


### PR DESCRIPTION
## Summary
- Add DEPRECATION NOTICE section to POD of all modules (Session2, Base, ServerStore, ClientStore, ClientStore2)
- Add `x_deprecated: 1` to `minil.toml` `[Metadata]` section and `META.json` so CPAN tooling recognizes this distribution as deprecated
- README.md also updated with deprecation notice (via `minil build` regeneration)

## Reference
- https://neilb.org/2015/01/17/deprecated-metadata.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)